### PR TITLE
[CICD-8031] port jenkins-call-url to python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #https://github.com/anapsix/docker-alpine-java
-FROM anapsix/alpine-java:8_jdk
+FROM nexus.303net.net:8443/anapsix/alpine-java:8_jdk
 
 ADD build/distributions/*.tar /usr/
 

--- a/scripts/init.groovy.d/aa_configure_credentials.groovy
+++ b/scripts/init.groovy.d/aa_configure_credentials.groovy
@@ -1,0 +1,368 @@
+/*
+   Copyright (c) 2015-2020 Sam Gleske - https://github.com/samrocketman/jenkins-bootstrap-shared
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   */
+/*
+   Configure multiple types of credentials.  Set the `credentials` binding with
+   a list of maps containing supported credential types.
+
+   Supported credential types include:
+     - BasicSSHUserPrivateKey
+     - StringCredentialsImpl
+   Example binding:
+
+     credentials = [
+         [
+             'credential_type': 'BasicSSHUserPrivateKey',
+             'credentials_id': 'some-credential-id',
+             'description': 'A description of this credential',
+             'user': 'some user',
+             'key_passwd': 'secret phrase',
+             'key': '''
+private key contents (do not indent it)
+             '''.trim()
+         ],
+         [
+             'credential_type': 'StringCredentialsImpl',
+             'credentials_id': 'some-credential-id',
+             'description': 'A description of this credential',
+             'secret': 'super secret text'
+         ],
+         [
+             'credential_type': 'UsernamePasswordCredentialsImpl',
+             'credentials_id': 'some-credential-id',
+             'description': 'A description of this credential',
+             'user': 'some user',
+             'password': 'secret phrase'
+         ]
+     ]
+ */
+
+
+// output init hook stage
+println '### JENKINS AUTOCONFIG: CREDENTIALS ###'
+
+/**
+  * Check if Jenkins should not configure itself and skip.
+  */
+
+Boolean skipConfiguringJenkins() {
+    !(System.env?.ENVIRONMENT in ['dev', 'staging']) ||
+        (new File("${Jenkins.instance.rootDir}/autoConfigComplete").exists())
+}
+if(skipConfiguringJenkins()) {
+    println 'Skipping Jenkins auto-configuration'
+    return
+}
+
+
+/**
+  * From this point onward Jenkins should configure itself.
+  */
+import jenkins.model.Jenkins
+
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse
+
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey
+import com.cloudbees.plugins.credentials.CredentialsMatchers
+import com.cloudbees.plugins.credentials.CredentialsProvider
+import com.cloudbees.plugins.credentials.CredentialsScope
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider
+import com.cloudbees.plugins.credentials.domains.Domain
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
+import hudson.security.ACL
+import hudson.util.Secret
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
+
+Map getSecret(Map options) {
+    String secretName = options.secretId
+    Region region = Region.of(options.region)
+    SecretsManagerClient client = SecretsManagerClient.builder()
+        .region(region)
+        .build()
+    GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest.builder()
+        .secretId(secretName)
+        .build()
+    GetSecretValueResponse getSecretValueResponse = client.getSecretValue(getSecretValueRequest)
+    String secret = getSecretValueResponse.secretString()
+    LoaderOptions loaderOptions = new LoaderOptions()
+    Yaml yaml = new Yaml(new SafeConstructor(loaderOptions))
+    yaml.load(secret)
+}
+
+// get environment vars passed to service container
+String ENVIRONMENT = System.env?.ENVIRONMENT
+// list of credential maps
+credentials = getSecret(region: 'us-east-1', secretId: "jenkins-ng/configuration/credentials/${ENVIRONMENT}").credentials
+
+
+/**
+  These methods are necessary for dynamic class loading.  This way, we can
+  optionally support agent plugins.  For example, we can support the SSH agent
+  plugin without requiring that it be installed if an admin does not need to
+  configure SSH agents.
+
+  This script will succeed both with and without the SSH slaves plugin
+  installed.
+ */
+Class loadClass(String clazz) {
+    try {
+        this.class.classLoader.loadClass(clazz)
+    }
+    catch(ClassNotFoundException e) {
+        null
+    }
+}
+
+List convertParameterTypes(List l) {
+    //this method is necessary to handle Java primitives defined in constructors
+    l.collect {
+        if(it in int) {
+            Integer
+        }
+        else if(it in boolean) {
+            Boolean
+        }
+        else if(it in CredentialsScope) {
+            CredentialsScope
+        }
+        else {
+            it
+        }
+    }
+}
+
+Boolean compareParameterTypesInListB(List a, List b) {
+    if(a.size() == b.size()) {
+        !(false in [convertParameterTypes(a), convertParameterTypes(b)].transpose().collect {
+            it[0] in it[1]
+        })
+    }
+    else {
+        false
+    }
+}
+
+/**
+  Return a new instance of a dynamically loaded class or null.  Useful to
+  attempt to instantiate classes on optional plugins and using in logic.
+ */
+def newClassInstance(String clazz, List argv = []) {
+    if(argv) {
+        loadClass(clazz)?.getConstructors().find {
+            compareParameterTypesInListB(it.parameterTypes.toList(), argv*.class)
+        }?.newInstance(*argv)
+    }
+    else {
+        loadClass(clazz)?.newInstance()
+    }
+}
+
+/**
+  Resolves a credential scope if given a string.
+  */
+def resolveScope(String scope) {
+    scope = scope.toString().toUpperCase()
+    if(!(scope in ['GLOBAL', 'SYSTEM'])) {
+        scope = 'GLOBAL'
+    }
+    CredentialsScope."${scope}"
+}
+
+/**
+  A shared method used by other "setCredential" methods to safely create a
+  credential in the global domain.
+  */
+def addCredential(String credentials_id, def credential) {
+    boolean modified_creds = false
+    Domain domain
+    SystemCredentialsProvider system_creds = SystemCredentialsProvider.getInstance()
+    Map system_creds_map = system_creds.getDomainCredentialsMap()
+    domain = (system_creds_map.keySet() as List).find { it.getName() == null }
+
+    List credentials = CredentialsProvider.lookupCredentials(credential.class, Jenkins.instance, ACL.SYSTEM)
+
+    if(!system_creds_map[domain] || !CredentialsMatchers.firstOrNull(credentials, CredentialsMatchers.withId(credentials_id))) {
+        if(system_creds_map[domain] && system_creds_map[domain].size() > 0) {
+            //other credentials exist so should only append
+            system_creds_map[domain] << credential
+        }
+        else {
+            system_creds_map[domain] = [credential]
+        }
+        modified_creds = true
+    }
+    //save any modified credentials
+    if(modified_creds) {
+        println "${credentials_id} credentials added to Jenkins."
+        system_creds.setDomainCredentialsMap(system_creds_map)
+        system_creds.save()
+    }
+    else {
+        println "Nothing changed.  ${credentials_id} credentials already configured."
+    }
+}
+
+/**
+  Supports SSH username and private key (directly entered private key)
+  credential provided by BasicSSHUserPrivateKey class.
+  Example:
+
+    [
+        'credential_type': 'BasicSSHUserPrivateKey',
+        'credentials_id': 'some-credential-id',
+        'description': 'A description of this credential',
+        'user': 'some user',
+        'key_passwd': 'secret phrase',
+        'key': '''
+private key contents (do not indent it)
+        '''.trim()
+    ]
+  */
+def setBasicSSHUserPrivateKey(Map settings) {
+    String credentials_id = ((settings['credentials_id'])?:'').toString()
+    String user = ((settings['user'])?:'').toString()
+    String key = ((settings['key'])?:'').toString()
+    String key_passwd = ((settings['key_passwd'])?:'').toString()
+    String description = ((settings['description'])?:'').toString()
+
+    addCredential(
+            credentials_id,
+            new BasicSSHUserPrivateKey(
+                resolveScope(settings['scope']),
+                credentials_id,
+                user,
+                new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(key),
+                key_passwd,
+                description)
+            )
+}
+
+/**
+  Supports String credential provided by StringCredentialsImpl class.
+  Example:
+
+    [
+        'credential_type': 'StringCredentialsImpl',
+        'credentials_id': 'some-credential-id',
+        'description': 'A description of this credential',
+        'secret': 'super secret text'
+    ]
+  */
+def setStringCredentialsImpl(Map settings) {
+    String credentials_id = ((settings['credentials_id'])?:'').toString()
+    String description = ((settings['description'])?:'').toString()
+    String secret = ((settings['secret'])?:'').toString()
+    addCredential(
+            credentials_id,
+            new StringCredentialsImpl(
+                resolveScope(settings['scope']),
+                credentials_id,
+                description,
+                Secret.fromString(secret))
+            )
+}
+
+/**
+  Supports username and password credential provided by
+  UsernamePasswordCredentialsImpl class.
+
+  Example:
+
+    [
+        'credential_type': 'UsernamePasswordCredentialsImpl',
+        'credentials_id': 'some-credential-id',
+        'description': 'A description of this credential',
+        'user': 'some user',
+        'password': 'secret phrase'
+    ]
+  */
+def setUsernamePasswordCredentialsImpl(Map settings) {
+    String credentials_id = ((settings['credentials_id'])?:'').toString()
+    String user = ((settings['user'])?:'').toString()
+    String password = ((settings['password'])?:'').toString()
+    String description = ((settings['description'])?:'').toString()
+
+    addCredential(
+            credentials_id,
+            new UsernamePasswordCredentialsImpl(
+                resolveScope(settings['scope']),
+                credentials_id,
+                description,
+                user,
+                password)
+            )
+}
+
+/**
+  Supports AWS credentials provided by the EC2 plugin AWSCredentialsImpl class.
+
+  Example:
+
+    [
+        'credential_type': 'AWSCredentialsImpl',
+        'credentials_id': 'some credentials id',
+        'description': 'A description of this credential',
+        'access_key': 'some access key',
+        'secret_key': 'some secret key',
+        'iam_role_arn': 'some iam role arn',
+        'iam_mfa_serial_number': 'some iam mfa serial number',
+        'scope': 'global'
+    ]
+
+  */
+def setAWSCredentialsImpl(Map settings) {
+    String credentials_id = ((settings['credentials_id'])?:'').toString()
+    String description = ((settings['description'])?:'').toString()
+
+    addCredential(
+            credentials_id,
+            newClassInstance('com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl',
+                [
+                    resolveScope(settings['scope']),
+                    credentials_id,
+                    settings['access_key'] ?: '',
+                    settings['secret_key'] ?: '',
+                    description,
+                    settings['iam_role_arn'] ?: '',
+                    settings['iam_mfa_serial_number'] ?: ''
+                ])
+            )
+}
+
+if(!binding.hasVariable('credentials')) {
+    credentials = []
+}
+if(!(credentials instanceof List<Map>)) {
+    throw new Exception('Error: credentials must be a list of maps.')
+}
+
+
+// iterate through credentials and add them to Jenkins
+credentials.each {
+    if("set${(it['credential_type'])?:'empty credential_type'}".toString() in (this.metaClass.methods*.name.toSet() - ['getSecret', 'skipConfiguringJenkins'])) {
+        "set${it['credential_type']}"(it)
+    }
+    else {
+        println "WARNING: Unknown credential type: ${(it['credential_type'])?:'empty credential_type'}.  Nothing changed."
+    }
+}
+
+null

--- a/scripts/init.groovy.d/ab_configure_github_oauth.groovy
+++ b/scripts/init.groovy.d/ab_configure_github_oauth.groovy
@@ -1,0 +1,114 @@
+/*
+   Copyright (c) 2015-2020 Sam Gleske - https://github.com/samrocketman/jenkins-bootstrap-jervis
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   */
+
+/*
+   Configures GitHub as the security realm from the GitHub Authentication
+   Plugin (github-oauth).
+
+   github-oauth 0.29
+ */
+
+
+// output init hook stage
+println '### JENKINS AUTOCONFIG: GITHUB OAUTH ###'
+
+/**
+  * Check if Jenkins should not configure itself and skip.
+  */
+
+Boolean skipConfiguringJenkins() {
+    !(System.env?.ENVIRONMENT in ['dev', 'staging']) ||
+        (new File("${Jenkins.instance.rootDir}/autoConfigComplete").exists())
+}
+if(skipConfiguringJenkins()) {
+    println 'Skipping Jenkins auto-configuration'
+    return
+}
+
+/**
+  * From this point onward Jenkins should configure itself.
+  */
+import jenkins.model.Jenkins
+
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse
+
+import hudson.security.SecurityRealm
+import org.jenkinsci.plugins.GithubSecurityRealm
+import net.sf.json.JSONObject
+
+Map getSecret(Map options) {
+    String secretName = options.secretId
+    Region region = Region.of(options.region)
+    SecretsManagerClient client = SecretsManagerClient.builder()
+        .region(region)
+        .build()
+    GetSecretValueRequest getSecretValueRequest = GetSecretValueRequest.builder()
+        .secretId(secretName)
+        .build()
+    GetSecretValueResponse getSecretValueResponse = client.getSecretValue(getSecretValueRequest)
+    String secret = getSecretValueResponse.secretString()
+    LoaderOptions loaderOptions = new LoaderOptions()
+    Yaml yaml = new Yaml(new SafeConstructor(loaderOptions))
+    yaml.load(secret)
+}
+String ENVIRONMENT = System.env?.ENVIRONMENT
+String HALF = System.env?.HALF
+
+// list of github realm maps
+github_realm = getSecret(region: 'us-east-1', secretId: "jenkins-ng/oauth/github")."${ENVIRONMENT}"."${HALF}".collectEntries()
+
+
+
+if(!binding.hasVariable('github_realm')) {
+    github_realm = [:]
+}
+
+if(!(github_realm instanceof Map)) {
+    throw new Exception('github_realm must be a Map.')
+}
+
+github_realm = github_realm as JSONObject
+
+def setGithubOauth(Map github_realm){
+    String githubWebUri = github_realm.optString('web_uri', GithubSecurityRealm.DEFAULT_WEB_URI)
+    String githubApiUri = github_realm.optString('api_uri', GithubSecurityRealm.DEFAULT_API_URI)
+    String oauthScopes = github_realm.optString('oauth_scopes', GithubSecurityRealm.DEFAULT_OAUTH_SCOPES)
+    String clientID = github_realm.optString('client_id')
+    String clientSecret = github_realm.optString('client_secret')
+    if(!Jenkins.instance.isQuietingDown()) {
+        if(clientID && clientSecret) {
+            SecurityRealm updated_github_realm = new GithubSecurityRealm(githubWebUri, githubApiUri, clientID, clientSecret, oauthScopes)
+            //check for equality, no need to modify the runtime if no settings changed
+            if(!updated_github_realm.equals(Jenkins.instance.getSecurityRealm())) {
+                Jenkins.instance.setSecurityRealm(updated_github_realm)
+                Jenkins.instance.save()
+                println 'Security realm configuration has changed.  Configured GitHub security realm.'
+            } else {
+                println 'Nothing changed.  GitHub security realm already configured.'
+            }
+        }
+    } else {
+        println 'Shutdown mode enabled.  Configure GitHub security realm SKIPPED.'
+    }
+}
+
+setGithubOauth(github_realm)

--- a/scripts/init.groovy.d/zz_complete_jenkins_setup.groovy
+++ b/scripts/init.groovy.d/zz_complete_jenkins_setup.groovy
@@ -1,0 +1,24 @@
+/**
+  * Check if Jenkins should not configure itself and skip.
+  */
+
+Boolean skipConfiguringJenkins() {
+    !(System.env?.ENVIRONMENT in ['dev', 'staging']) ||
+        (new File("${Jenkins.instance.rootDir}/autoConfigComplete").exists())
+}
+if(skipConfiguringJenkins()) {
+    println 'Skipping Jenkins auto-configuration'
+    return
+}
+
+/**
+  * From this point onward Jenkins should configure itself.
+  */
+import jenkins.model.Jenkins
+
+void setConfigurationComplete() {
+  new File("${Jenkins.instance.rootDir}/autoConfigComplete").withWriter { w -> w << '' }
+  println 'Jenkins autoconfiguration complete, writing flag file...'
+}
+
+setConfigurationComplete()

--- a/scripts/jenkins-call-url
+++ b/scripts/jenkins-call-url
@@ -239,6 +239,10 @@ def getUrl(url, headers, data=None, method='GET'):
     responseString = ""
     responseErrorReason = None
     try:
+        # Convert the string data to bytes if it's not None
+        if data is not None:
+            data = data.encode('utf-8')
+
         if url.startswith('https'):
             # https://docs.python.org/3/library/ssl.html#ssl-security
             context = ssl.create_default_context()

--- a/scripts/jenkins-call-url
+++ b/scripts/jenkins-call-url
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-#Created by Sam Gleske
-#Copyright 2017 Sam Gleske
-#LICENSE MIT
-#Source: https://github.com/samrocketman/home/blob/master/bin/jenkins-call-url
-#The above comment block must remain intact for usage.
+# Created by Sam Gleske
+# Copyright 2017 Sam Gleske
+# LICENSE MIT
+# Source: https://github.com/samrocketman/home/blob/master/bin/jenkins-call-url
+# The above comment block must remain intact for usage.
 
-#DESCRIPTION:
+# DESCRIPTION:
 #  Reads Jenkins API and can make calls to arbitrary Jenkins URL endpoints.
-#EXAMPLES:
+# EXAMPLES:
 #  Execute script console script.
 #      jenkins-call-url -m POST --data-string "script=println 'hello world'" http://localhost:8080/scriptText
 #  Execute a whole Groovy script on script console.
@@ -23,9 +23,7 @@ import os
 import re
 import ssl
 import sys
-import time
 
-from http.client import HTTPSConnection
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
@@ -63,7 +61,7 @@ examples:
       export JENKINS_CALL_ARGS="-m POST -v --data-string script= http://localhost:8080/scriptText --data-file"
       jenkins-call-url ./script.groovy
 """, formatter_class=argparse.RawTextHelpFormatter)
-parser.add_argument('--version', action='version', version="%(prog)s "+version)
+parser.add_argument('--version', action='version', version="%(prog)s " + version)
 parser.add_argument('--curl', action='store_true', dest='print_curl', help='Print a fully formatted curl command which includes all options for debugging and exit.')
 parser.add_argument('--curl-init', action='store_true', dest='print_curl_init', help='Print a formatted initial curl command for debugging and exit.')
 parser.add_argument('--curl-crumb', action='store_true', dest='print_curl_crumb', help='Print a formatted curl command for getting CSRF crumb for debugging and exit.')
@@ -91,11 +89,13 @@ if len(additional_args) > 0:
         sys.argv = [sys.argv[0]] + additional_args.strip().split() + sys.argv[1:]
 args = parser.parse_args()
 
+
 def trim_url_slash(url):
     return url[:-1] if url.endswith('/') else url
 
+
 def printCurl(settings, url=trim_url_slash(args.jenkins_web)):
-    curl='curl'
+    curl = 'curl'
     headers = settings['headers']
     if 'socks_proxy' in settings and len(settings['socks_proxy']) > 0:
         curl += f" --proxy socks5h://{settings['socks_proxy']}"
@@ -117,18 +117,21 @@ def printCurl(settings, url=trim_url_slash(args.jenkins_web)):
         curl += '"'
     if args.pinned_cert:
         curl += f" --cacert {args.pinned_cert}"
-    for k,v in headers.items():
+    for k, v in headers.items():
         curl += f" -H '{k}:{v}'"
     print(curl, url)
     sys.exit(1)
 
+
 def getHost(url):
     return url.split('/')[2].split(':')[0]
+
 
 # print to stderr
 def print_err(message=''):
     sys.stderr.write(f"{message}\n")
     sys.stderr.flush()
+
 
 # validate http method
 if args.http_method not in ['GET', 'HEAD', 'POST']:
@@ -221,12 +224,13 @@ if args.print_curl_init:
     else:
         printCurl(settings)
 
-### POST-PROXY SETTINGS using python3 urllib
+# POST-PROXY SETTINGS using python3 urllib
 # See: https://stackoverflow.com/questions/2317849/how-can-i-use-a-socks-4-5-proxy-with-urllib2
 # Note: SOCKS proxy must always be configured before importing urllib
 # Note: urllib and urllib2 have been combined into one library for python3
 
 import urllib
+
 
 def getUrl(url, headers, data=None, method='GET'):
     if args.verbosity >= 3:
@@ -236,7 +240,7 @@ def getUrl(url, headers, data=None, method='GET'):
     responseErrorReason = None
     try:
         if url.startswith('https'):
-            #https://docs.python.org/3/library/ssl.html#ssl-security
+            # https://docs.python.org/3/library/ssl.html#ssl-security
             context = ssl.create_default_context()
             if args.pinned_cert:
                 context.load_verify_locations(cafile=args.pinned_cert)
@@ -266,6 +270,7 @@ def getUrl(url, headers, data=None, method='GET'):
         responseErrorReason = e.reason
     return (responseCode, responseString, responseErrorReason)
 
+
 def getJSONUrl(url, headers):
     if not url.endswith('/api/json'):
         url = url + '/api/json'
@@ -279,8 +284,9 @@ def getJSONUrl(url, headers):
     return parsed
 
 #
-### END POST-PROXY SETTINGS using urllib and urllib2
+# END POST-PROXY SETTINGS using urllib and urllib2
 #
+
 
 # complete arguments for use
 jenkins_url = trim_url_slash(args.JENKINS_URL)
@@ -335,7 +341,7 @@ if args.verbosity >= 1:
     print_err(f"{args.http_method} {jenkins_url}")
 
 # prepare the HTTP message body payload
-data=None
+data = None
 if len(args.http_data_files) > 0:
     data = ""
     for string in args.http_data_strings:
@@ -369,13 +375,13 @@ if len(args.save_headers_file) > 0:
         print_err("Saving HTTP headers to file.")
     with open(args.save_headers_file, 'w') as f:
         settings['headers'] = headers
-        json.dump(settings,f)
+        json.dump(settings, f)
     # credentials are stored in the headers file so don't want just anybody to read it
     os.chmod(args.save_headers_file, 0o600)
 
 STATUS = 0
 if reason:
-    STATUS=1
+    STATUS = 1
     if args.verbosity >= 1:
         print_err(reason)
 sys.exit(STATUS)

--- a/scripts/jenkins-call-url
+++ b/scripts/jenkins-call-url
@@ -98,27 +98,27 @@ def printCurl(settings, url=trim_url_slash(args.jenkins_web)):
     curl='curl'
     headers = settings['headers']
     if 'socks_proxy' in settings and len(settings['socks_proxy']) > 0:
-        curl += ' --proxy socks5h://%s' % settings['socks_proxy']
+        curl += f" --proxy socks5h://{settings['socks_proxy']}"
     if args.http_method != 'GET' and url != trim_url_slash(args.jenkins_web):
         if args.http_method == 'HEAD':
             curl += " --head"
         else:
-            curl += " -X%s" % args.http_method
+            curl += f" -X{args.http_method}"
     if len(args.http_data_files) > 0 and url != trim_url_slash(args.jenkins_web):
         curl += ' --data-urlencode "'
         if len(args.http_data_strings) > 0:
             for s in args.http_data_strings:
-                curl += '%s' % s
+                curl += "{s}"
         for f in args.http_data_files:
             if f == '-':
                 curl += sys.stdin.read()
             else:
-                curl += '$(<%s)' % f
+                curl += f"$(<{f})"
         curl += '"'
     if args.pinned_cert:
-        curl += ' --cacert %s' % args.pinned_cert
+        curl += f" --cacert {args.pinned_cert}"
     for k,v in headers.items():
-        curl += " -H '%s:%s'" % (k, v)
+        curl += f" -H '{k}:{v}'"
     print(curl, url)
     sys.exit(1)
 
@@ -127,7 +127,7 @@ def getHost(url):
 
 # print to stderr
 def print_err(message=''):
-    sys.stderr.write(message + '\n')
+    sys.stderr.write(f"{message}\n")
     sys.stderr.flush()
 
 # validate http method
@@ -162,7 +162,7 @@ if args.auto_jenkins_web:
     headers['Host'] = getHost(trim_url_slash(args.JENKINS_URL))
 
 # always set the User-Agent
-headers['User-Agent'] = 'jenkins-call-url %s' % version
+headers['User-Agent'] = f"jenkins-call-url {version}"
 
 if 'Authorization' in headers:
     if args.verbosity >= 2:
@@ -170,9 +170,9 @@ if 'Authorization' in headers:
 else:
     if username is not None:
         if args.verbosity >= 2:
-            print_err("Logging in as user %s." % username)
+            print_err(f"Logging in as user {username}.")
         # encode the username and password strings as bytes before base64 encoding them
-        credentials = ("%s:%s" % (username, password)).encode('ascii')
+        credentials = (f"{username}:{password}").encode('ascii')
         headers['Authorization'] = b"Basic " + base64.b64encode(credentials)
 
 # configure SOCKS5 proxy
@@ -186,13 +186,13 @@ else:
     proxy = ''
 
 if proxy and not re.match(r'[-0-9a-zA-Z.]+:[0-9]+', proxy):
-    print_err("Invalid --proxy specified: %s" % args.socks_proxy)
+    print_err(f"Invalid --proxy specified: {args.socks_proxy}")
     parser.print_help()
     sys.exit(1)
 
 if proxy:
     if args.verbosity >= 1:
-        print_err("Using SOCKS5 proxy: %s" % proxy)
+        print_err(f"Using SOCKS5 proxy: {proxy}")
     settings['socks_proxy'] = proxy
     proxy_host = proxy.split(':')[0]
     proxy_port = int(proxy.split(':')[1])
@@ -210,9 +210,9 @@ if args.print_curl_crumb:
     settings['headers'] = headers
     args.http_method = 'POST'
     if args.auto_jenkins_web:
-        printCurl(settings, args.JENKINS_URL + '/crumbIssuer/api/json?pretty=true')
+        printCurl(settings, f"{args.JENKINS_URL}/crumbIssuer/api/json?pretty=true")
     else:
-        printCurl(settings, args.jenkins_web + '/crumbIssuer/api/json?pretty=true')
+        printCurl(settings, f"{args.jenkins_web}/crumbIssuer/api/json?pretty=true")
 
 if args.print_curl_init:
     settings['headers'] = headers
@@ -230,7 +230,7 @@ import urllib
 
 def getUrl(url, headers, data=None, method='GET'):
     if args.verbosity >= 3:
-        print_err('%s %s' % (method, url))
+        print_err(f"{method} {url}")
     responseCode = -1
     responseString = ""
     responseErrorReason = None
@@ -271,7 +271,7 @@ def getJSONUrl(url, headers):
         url = url + '/api/json'
     code, response, reason = getUrl(url, headers)
     if reason:
-        print_err("HTTP ERROR %s: %s\n%s" % (str(code), reason, url))
+        print_err(f"HTTP ERROR {code}: {reason}\n{url}")
         sys.exit(1)
     # Python 3 expects response var to be in bytes
     # need to be decode to a string using the decode() method with utf-8 encoding
@@ -332,7 +332,7 @@ if args.print_curl:
     printCurl(settings, url=jenkins_url)
 
 if args.verbosity >= 1:
-    print_err("%s %s" % (args.http_method, jenkins_url))
+    print_err(f"{args.http_method} {jenkins_url}")
 
 # prepare the HTTP message body payload
 data=None
@@ -350,7 +350,7 @@ if len(args.http_data_files) > 0:
 # Call the URL
 code, response, reason = getUrl(jenkins_url, headers, method=args.http_method, data=data)
 if args.verbosity >= 1:
-    print_err("Response (HTTP %s):" % str(code))
+    print_err(f"Response (HTTP {code}):")
 # print without newline at end
 if len(response) > 0:
     if args.output == '-':

--- a/scripts/jenkins-call-url
+++ b/scripts/jenkins-call-url
@@ -16,7 +16,6 @@
 #      export JENKINS_CALL_ARGS="-m POST -v --data-string script= http://localhost:8080/scriptText --data-file"
 #      jenkins-call-url ./script.groovy
 
-from http.client import HTTPSConnection
 import argparse
 import base64
 import json
@@ -25,6 +24,10 @@ import re
 import ssl
 import sys
 import time
+
+from http.client import HTTPSConnection
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
 
 try:
     import socket
@@ -218,12 +221,12 @@ if args.print_curl_init:
     else:
         printCurl(settings)
 
-### POST-PROXY SETTINGS using urllib and urllib2
+### POST-PROXY SETTINGS using python3 urllib
 # See: https://stackoverflow.com/questions/2317849/how-can-i-use-a-socks-4-5-proxy-with-urllib2
-# Note: SOCKS proxy must always be configured before importing urllib and urllib2
+# Note: SOCKS proxy must always be configured before importing urllib
+# Note: urllib and urllib2 have been combined into one library for python3
 
 import urllib
-import urllib2
 
 def getUrl(url, headers, data=None, method='GET'):
     if args.verbosity >= 3:
@@ -239,15 +242,15 @@ def getUrl(url, headers, data=None, method='GET'):
                 context.load_verify_locations(cafile=args.pinned_cert)
             else:
                 context.load_default_certs()
-            req = urllib.request.Request(url, data=data, headers=headers)
+            req = Request(url, data=data, headers=headers)
             if method != 'GET':
                 req.get_method = lambda: method
-            urlconn = urllib.request.urlopen(req, context=context)
+            urlconn = urlopen(req, context=context)
         else:
-            req = urllib.request.Request(url=url, data=data, headers=headers)
+            req = Request(url=url, data=data, headers=headers)
             if method != 'GET':
                 req.get_method = lambda: method
-            urlconn = urllib.request.urlopen(req)
+            urlconn = urlopen(req)
         responseString = urlconn.read().decode()
         if url.endswith('crumbIssuer/api/json'):
             if 'Cookie' in headers:
@@ -258,7 +261,7 @@ def getUrl(url, headers, data=None, method='GET'):
                     print_err('Set a new session cookie ' + headers['Cookie'])
         responseCode = urlconn.getcode()
         urlconn.close()
-    except urllib.error.HTTPError as e:
+    except HTTPError as e:
         responseCode = e.code
         responseErrorReason = e.reason
     return (responseCode, responseString, responseErrorReason)

--- a/scripts/jenkins-call-url
+++ b/scripts/jenkins-call-url
@@ -1,10 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #Created by Sam Gleske
 #Copyright 2017 Sam Gleske
-#Tue Mar 21 17:24:36 PDT 2017
-#Ubuntu 16.04.1 LTS
-#Linux 4.4.0-59-generic x86_64
-#Python 2.7.12
 #LICENSE MIT
 #Source: https://github.com/samrocketman/home/blob/master/bin/jenkins-call-url
 #The above comment block must remain intact for usage.
@@ -20,7 +16,7 @@
 #      export JENKINS_CALL_ARGS="-m POST -v --data-string script= http://localhost:8080/scriptText --data-file"
 #      jenkins-call-url ./script.groovy
 
-from httplib import HTTPSConnection
+from http.client import HTTPSConnection
 import argparse
 import base64
 import json
@@ -83,17 +79,17 @@ parser.add_argument('-v', '--verbosity', action="count", dest='verbosity', help=
 parser.add_argument('--raw-response', action='store_true', dest='raw_response', help='By default, script console responses are stripped of leading and trailing spaces.  This option disables the behavior and renders the literal response from Jenkins.')
 parser.add_argument('JENKINS_URL', help='The URL to a Jenkins endpoint to call.')
 
-#prepend additional arguments from environment
+# prepend additional arguments from environment
 additional_args = os.getenv('JENKINS_CALL_ARGS', '')
 if len(additional_args) > 0:
-  if '|' in list(additional_args):
-      sys.argv = [sys.argv[0]] + additional_args.strip().split('|') + sys.argv[1:]
-  else:
-      sys.argv = [sys.argv[0]] + additional_args.strip().split() + sys.argv[1:]
+    if '|' in additional_args:
+        sys.argv = [sys.argv[0]] + additional_args.strip().split('|') + sys.argv[1:]
+    else:
+        sys.argv = [sys.argv[0]] + additional_args.strip().split() + sys.argv[1:]
 args = parser.parse_args()
 
 def trim_url_slash(url):
-    return url[:-1] if url[-1:] == '/' else url
+    return url[:-1] if url.endswith('/') else url
 
 def printCurl(settings, url=trim_url_slash(args.jenkins_web)):
     curl='curl'
@@ -120,33 +116,35 @@ def printCurl(settings, url=trim_url_slash(args.jenkins_web)):
         curl += ' --cacert %s' % args.pinned_cert
     for k,v in headers.items():
         curl += " -H '%s:%s'" % (k, v)
-    print curl, url
+    print(curl, url)
     sys.exit(1)
 
 def getHost(url):
     return url.split('/')[2].split(':')[0]
 
-#print to stderr
-def printErr(message=''):
+# print to stderr
+def print_err(message=''):
     sys.stderr.write(message + '\n')
     sys.stderr.flush()
 
-if not args.http_method in ['GET', 'HEAD', 'POST']:
-    printErr("Invalid --http-method specified: %s" % args.http_method)
+# validate http method
+if args.http_method not in ['GET', 'HEAD', 'POST']:
+    print_err(f"Invalid --http-method specified: {args.http_method}")
     parser.print_help()
     sys.exit(1)
 
-#build credentials
+# get credentials
 username = os.getenv('JENKINS_USER')
 password = os.getenv('JENKINS_PASSWORD')
 
-if len(args.load_headers_file) > 0 and os.path.exists(args.load_headers_file) and os.path.getsize(args.load_headers_file) > 0:
+# load settings from file, if specified
+settings = {}
+load_headers_file = args.load_headers_file.strip()
+if load_headers_file and os.path.isfile(load_headers_file) and os.path.getsize(load_headers_file) > 0:
     if args.verbosity >= 2:
-        printErr("Loading HTTP headers from JSON file.")
-    with open(args.load_headers_file) as f:
+        print_err("Loading HTTP headers from JSON file.")
+    with open(load_headers_file) as f:
         settings = json.load(f)
-else:
-    settings = {}
 
 if 'headers' in settings:
     headers = settings['headers']
@@ -160,47 +158,49 @@ else:
 if args.auto_jenkins_web:
     headers['Host'] = getHost(trim_url_slash(args.JENKINS_URL))
 
-#always set the User-Agent
+# always set the User-Agent
 headers['User-Agent'] = 'jenkins-call-url %s' % version
 
 if 'Authorization' in headers:
     if args.verbosity >= 2:
-        printErr("Reusing Authorization from HTTP headers file.")
+        print_err("Reusing Authorization from HTTP headers file.")
 else:
-    if not username == None:
+    if username is not None:
         if args.verbosity >= 2:
-            printErr("Logging in as user %s." % username)
-        headers['Authorization'] = "Basic %s" % base64.b64encode("%s:%s" % (username, password)).decode('ascii')
+            print_err("Logging in as user %s." % username)
+        # encode the username and password strings as bytes before base64 encoding them
+        credentials = ("%s:%s" % (username, password)).encode('ascii')
+        headers['Authorization'] = b"Basic " + base64.b64encode(credentials)
 
-#configure SOCKS5 proxy
-if args.socks_proxy != None:
+# configure SOCKS5 proxy
+if args.socks_proxy is not None:
     proxy = args.socks_proxy
 elif 'socks_proxy' in settings:
     if args.verbosity >= 2:
-        printErr("Reusing proxy configuration from headers file.")
+        print_err("Reusing proxy configuration from headers file.")
     proxy = str(settings['socks_proxy'])
 else:
     proxy = ''
 
 if proxy and not re.match(r'[-0-9a-zA-Z.]+:[0-9]+', proxy):
-    printErr("Invalid --proxy specified: %s" % args.socks_proxy)
+    print_err("Invalid --proxy specified: %s" % args.socks_proxy)
     parser.print_help()
     sys.exit(1)
 
 if proxy:
     if args.verbosity >= 1:
-        printErr("Using SOCKS5 proxy: %s" % proxy)
+        print_err("Using SOCKS5 proxy: %s" % proxy)
     settings['socks_proxy'] = proxy
     proxy_host = proxy.split(':')[0]
     proxy_port = int(proxy.split(':')[1])
     if not socks_supported:
-        printErr("WARNING: Python socks module not installed so socks is not supported")
+        print_err("WARNING: Python socks module not installed so socks is not supported")
     else:
         socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, proxy_host, proxy_port)
         socket.socket = socks.socksocket
 else:
     if args.verbosity >= 3:
-        printErr("Removing proxy configuration from headers file.")
+        print_err("Removing proxy configuration from headers file.")
     settings.pop('socks_proxy', None)
 
 if args.print_curl_crumb:
@@ -218,7 +218,6 @@ if args.print_curl_init:
     else:
         printCurl(settings)
 
-#
 ### POST-PROXY SETTINGS using urllib and urllib2
 # See: https://stackoverflow.com/questions/2317849/how-can-i-use-a-socks-4-5-proxy-with-urllib2
 # Note: SOCKS proxy must always be configured before importing urllib and urllib2
@@ -228,7 +227,7 @@ import urllib2
 
 def getUrl(url, headers, data=None, method='GET'):
     if args.verbosity >= 3:
-        printErr('%s %s' % (method, url))
+        print_err('%s %s' % (method, url))
     responseCode = -1
     responseString = ""
     responseErrorReason = None
@@ -240,26 +239,26 @@ def getUrl(url, headers, data=None, method='GET'):
                 context.load_verify_locations(cafile=args.pinned_cert)
             else:
                 context.load_default_certs()
-            req = urllib2.Request(url, data=data, headers=headers)
+            req = urllib.request.Request(url, data=data, headers=headers)
             if method != 'GET':
                 req.get_method = lambda: method
-            urlconn = urllib2.urlopen(req, context=context)
+            urlconn = urllib.request.urlopen(req, context=context)
         else:
-            req = urllib2.Request(url=url, data=data, headers=headers)
+            req = urllib.request.Request(url=url, data=data, headers=headers)
             if method != 'GET':
                 req.get_method = lambda: method
-            urlconn = urllib2.urlopen(req)
-        responseString = urlconn.read()
+            urlconn = urllib.request.urlopen(req)
+        responseString = urlconn.read().decode()
         if url.endswith('crumbIssuer/api/json'):
-            if headers.has_key('Cookie'):
+            if 'Cookie' in headers:
                 headers.pop('Cookie')
-            if urlconn.info().has_key('Set-Cookie'):
+            if 'Set-Cookie' in urlconn.info():
                 headers['Cookie'] = urlconn.info()['Set-Cookie']
                 if args.verbosity >= 2:
-                    printErr('Set a new session cookie ' + headers['Cookie'])
+                    print_err('Set a new session cookie ' + headers['Cookie'])
         responseCode = urlconn.getcode()
         urlconn.close()
-    except urllib2.HTTPError as e:
+    except urllib.error.HTTPError as e:
         responseCode = e.code
         responseErrorReason = e.reason
     return (responseCode, responseString, responseErrorReason)
@@ -269,25 +268,27 @@ def getJSONUrl(url, headers):
         url = url + '/api/json'
     code, response, reason = getUrl(url, headers)
     if reason:
-        printErr("HTTP ERROR %s: %s\n%s" % (str(code), reason, url))
+        print_err("HTTP ERROR %s: %s\n%s" % (str(code), reason, url))
         sys.exit(1)
-    parsed = json.loads(response)
+    # Python 3 expects response var to be in bytes
+    # need to be decode to a string using the decode() method with utf-8 encoding
+    parsed = json.loads(response.decode('utf-8'))
     return parsed
 
 #
 ### END POST-PROXY SETTINGS using urllib and urllib2
 #
 
-#complete arguments for use
+# complete arguments for use
 jenkins_url = trim_url_slash(args.JENKINS_URL)
 jenkins_web = ''
 jenkins_root_api_response = {}
 
 if args.auto_jenkins_web:
-    #force a crumb reload since we're resolving JENKINS_WEB
+    # force a crumb reload since we're resolving JENKINS_WEB
     args.force_crumb = True
     if args.verbosity >= 2:
-        printErr("Automatically resolving JENKINS_WEB.")
+        print_err("Automatically resolving JENKINS_WEB.")
     jenkins_web = jenkins_url
     if jenkins_web[-8:] == 'api/json':
         jenkins_web = jenkins_web[:-8]
@@ -305,32 +306,32 @@ if len(args.load_headers_file) == 0 or args.force_crumb or not os.path.exists(ar
     if not args.auto_jenkins_web:
         jenkins_web = trim_url_slash(args.jenkins_web)
         if not jenkins_url.startswith(jenkins_web):
-            printErr("ERROR: JENKINS_URL does not start with JENKINS_WEB.  See --help for -s or -a.")
+            print_err("ERROR: JENKINS_URL does not start with JENKINS_WEB.  See --help for -s or -a.")
             sys.exit(2)
         jenkins_root_api_response = getJSONUrl(jenkins_web + '/api/json', headers)
 
-    #detect CSRF protection
+    # detect CSRF protection
     if jenkins_root_api_response['useCrumbs']:
         if args.verbosity >= 2:
-            printErr("CSRF protection enabled.")
+            print_err("CSRF protection enabled.")
         csrf_crumb = getJSONUrl(jenkins_web + '/crumbIssuer', headers)
         headers[csrf_crumb["crumbRequestField"]] = csrf_crumb["crumb"]
     else:
         if args.verbosity >= 2:
-            printErr("CSRF protection disabled.")
+            print_err("CSRF protection disabled.")
 else:
     if args.verbosity >= 2:
-        printErr("Reusing CSRF crumb from HTTP headers file.")
+        print_err("Reusing CSRF crumb from HTTP headers file.")
 
-#include the full operation
+# include the full operation
 if args.print_curl:
     settings['headers'] = headers
     printCurl(settings, url=jenkins_url)
 
 if args.verbosity >= 1:
-    printErr("%s %s" % (args.http_method, jenkins_url))
+    print_err("%s %s" % (args.http_method, jenkins_url))
 
-#prepare the HTTP message body payload
+# prepare the HTTP message body payload
 data=None
 if len(args.http_data_files) > 0:
     data = ""
@@ -343,11 +344,11 @@ if len(args.http_data_files) > 0:
             with open(path) as f:
                 data += urllib.quote(f.read())
 
-#Call the URL
+# Call the URL
 code, response, reason = getUrl(jenkins_url, headers, method=args.http_method, data=data)
 if args.verbosity >= 1:
-    printErr("Response (HTTP %s):" % str(code))
-#print without newline at end
+    print_err("Response (HTTP %s):" % str(code))
+# print without newline at end
 if len(response) > 0:
     if args.output == '-':
         if args.raw_response:
@@ -362,18 +363,18 @@ if len(response) > 0:
 
 if len(args.save_headers_file) > 0:
     if args.verbosity >= 2:
-        printErr("Saving HTTP headers to file.")
+        print_err("Saving HTTP headers to file.")
     with open(args.save_headers_file, 'w') as f:
         settings['headers'] = headers
         json.dump(settings,f)
-    #credentials are stored in the headers file so don't want just anybody to read it
+    # credentials are stored in the headers file so don't want just anybody to read it
     os.chmod(args.save_headers_file, 0o600)
 
 STATUS = 0
 if reason:
     STATUS=1
     if args.verbosity >= 1:
-        printErr(reason)
+        print_err(reason)
 sys.exit(STATUS)
 
 # CHANGELOG

--- a/tests/deb/run
+++ b/tests/deb/run
@@ -24,6 +24,6 @@ while [ $# -gt 1 ]; do
 done
 # $1 is left intact to be run as the shell command in the docker image
 
-DOCKER_IMAGE="ubuntu:16.04"
+DOCKER_IMAGE='nexus.303net.net:8443/library/ubuntu:16.04'
 docker pull "${DOCKER_IMAGE}"
 docker run "${args[@]}" -w /mnt -t --rm -v "$PWD":/mnt "${DOCKER_IMAGE}" "${1:-/mnt/tests/deb/validate.sh}"

--- a/tests/rpm/run
+++ b/tests/rpm/run
@@ -24,6 +24,6 @@ while [ $# -gt 1 ]; do
 done
 # $1 is left intact to be run as the shell command in the docker image
 
-DOCKER_IMAGE="centos:7"
+DOCKER_IMAGE='nexus.303net.net:8443/library/centos:7'
 docker pull "${DOCKER_IMAGE}"
 docker run "${args[@]}" -w /mnt -t --rm -v "$PWD":/mnt "${DOCKER_IMAGE}" "${1:-/mnt/tests/rpm/validate.sh}"


### PR DESCRIPTION
See also: [CICD-8031](https://jira.integralads.com/browse/CICD-8031)

Make required changes for `jenkins-call-url` script to run on Python 3 so we don't need to use an outdated Python version any more.

TODO:
* Use f-strings instead of current string formatting ✅
* ~~Abstract into single class?~~
* Verify and fix as-needed